### PR TITLE
fix(telephony): separate CRM and dialer campaigns; fix sidebar highli…

### DIFF
--- a/app/Http/Controllers/Api/CallController.php
+++ b/app/Http/Controllers/Api/CallController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Services\Telephony\CallOrchestrationService;
 use App\Services\Telephony\PredictiveDialerService;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -12,7 +13,7 @@ class CallController extends Controller
 {
     public function __construct(
         protected CallOrchestrationService $orchestration,
-        protected PredictiveDialerService $predictiveDialer
+        protected PredictiveDialerService $predictiveDialer,
     ) {}
 
     /**
@@ -26,7 +27,7 @@ class CallController extends Controller
             'phone_code' => ['nullable', 'string', 'max:5'],
         ]);
 
-        $campaign = $request->query('campaign') ?: $request->session()->get('campaign', 'mbsales');
+        $campaign = $request->query('campaign') ?: TelephonyCampaignResolver::forRequest($request);
         $phoneNumber = $request->input('phone_number') ?: $request->query('phone_number') ?: $request->input('phone');
 
         if (empty($phoneNumber)) {
@@ -38,7 +39,7 @@ class CallController extends Controller
             $campaign,
             $phoneNumber,
             $request->input('lead_id') ? (int) $request->input('lead_id') : null,
-            $request->input('phone_code', '1')
+            $request->input('phone_code', '1'),
         );
 
         if (! $result->success) {
@@ -46,6 +47,7 @@ class CallController extends Controller
             if (is_array($result->data) && isset($result->data['error_code'])) {
                 $payload['error'] = $result->data;
             }
+
             return response()->json($payload, 422);
         }
 
@@ -124,7 +126,7 @@ class CallController extends Controller
      */
     public function predictiveDial(Request $request): JsonResponse
     {
-        $campaign = $request->query('campaign') ?: $request->session()->get('campaign', 'mbsales');
+        $campaign = $request->query('campaign') ?: TelephonyCampaignResolver::forRequest($request);
         $result = $this->predictiveDialer->dialNext($request->user(), $campaign);
 
         if (! $result->success) {

--- a/app/Http/Controllers/Api/CallbackController.php
+++ b/app/Http/Controllers/Api/CallbackController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Services\Telephony\CallbackService;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -29,7 +30,7 @@ class CallbackController extends Controller
             strtoupper((string) ($validated['callback_type'] ?? 'ANYONE')),
             $validated['callback_user'] ?? null,
             $validated['callback_comments'] ?? null,
-            (string) ($validated['callback_status'] ?? 'CALLBK')
+            (string) ($validated['callback_status'] ?? 'CALLBK'),
         );
 
         return $this->respond($result);
@@ -45,7 +46,7 @@ class CallbackController extends Controller
         return $this->respond($service->remove(
             $request->user(),
             $this->campaign($request, $validated),
-            (int) $validated['lead_id']
+            (int) $validated['lead_id'],
         ));
     }
 
@@ -61,13 +62,18 @@ class CallbackController extends Controller
             $request->user(),
             $this->campaign($request, $validated),
             (int) $validated['lead_id'],
-            strtoupper((string) ($validated['search_location'] ?? 'ALL'))
+            strtoupper((string) ($validated['search_location'] ?? 'ALL')),
         ));
     }
 
     protected function campaign(Request $request, array $validated = []): string
     {
-        return (string) ($validated['campaign'] ?? $request->input('campaign', $request->session()->get('campaign', 'mbsales')));
+        $explicit = $validated['campaign'] ?? $request->input('campaign');
+
+        return TelephonyCampaignResolver::resolve(
+            $request,
+            is_string($explicit) && $explicit !== '' ? $explicit : null,
+        );
     }
 
     protected function respond($result): JsonResponse

--- a/app/Http/Controllers/Api/DtmfController.php
+++ b/app/Http/Controllers/Api/DtmfController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Services\Telephony\DtmfService;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -18,8 +19,8 @@ class DtmfController extends Controller
 
         $result = $service->send(
             $request->user(),
-            (string) ($validated['campaign'] ?? $request->session()->get('campaign', 'mbsales')),
-            $validated['digits']
+            TelephonyCampaignResolver::resolve($request, $validated['campaign'] ?? null),
+            $validated['digits'],
         );
 
         return response()->json([

--- a/app/Http/Controllers/Api/NextLeadController.php
+++ b/app/Http/Controllers/Api/NextLeadController.php
@@ -15,11 +15,11 @@ class NextLeadController extends Controller
 {
     public function __invoke(Request $request): JsonResponse
     {
-        $campaign = $request->query('campaign') ?: $request->session()->get('campaign', 'mbsales');
+        $campaign = $request->query('campaign') ?: (string) $request->session()->get('campaign', 'mbsales');
         $user = $request->user();
 
         // Throttle: prevent rapid-fire requests from the same agent
-        $cacheKey = 'next_lead_throttle_' . $user->id;
+        $cacheKey = 'next_lead_throttle_'.$user->id;
         if (Cache::has($cacheKey)) {
             return response()->json([
                 'success' => true,
@@ -35,17 +35,17 @@ class NextLeadController extends Controller
             return response()->json([
                 'success' => true,
                 'lead' => [
-                    'lead_id'      => $lead->lead_id,
+                    'lead_id' => $lead->lead_id,
                     'phone_number' => $lead->phone_number,
-                    'client_name'  => $lead->client_name,
-                    'custom_data'  => $lead->custom_data ?? [],
+                    'client_name' => $lead->client_name,
+                    'custom_data' => $lead->custom_data ?? [],
                 ],
             ]);
         }
 
         return response()->json([
             'success' => true,
-            'lead'    => null,
+            'lead' => null,
             'message' => 'No leads available in the hopper.',
         ]);
     }
@@ -74,10 +74,10 @@ class NextLeadController extends Controller
                 }
 
                 $lead->update([
-                    'status'              => 'assigned',
+                    'status' => 'assigned',
                     'assigned_to_user_id' => $userId,
-                    'assigned_at'         => now(),
-                    'last_attempted_at'   => now(),
+                    'assigned_at' => now(),
+                    'last_attempted_at' => now(),
                 ]);
 
                 return $lead;
@@ -85,8 +85,8 @@ class NextLeadController extends Controller
         } catch (\Throwable $e) {
             Log::error('NextLeadController: failed to fetch next lead', [
                 'campaign' => $campaign,
-                'user_id'  => $userId,
-                'error'    => $e->getMessage(),
+                'user_id' => $userId,
+                'error' => $e->getMessage(),
             ]);
 
             return null;

--- a/app/Http/Controllers/Api/RecordingController.php
+++ b/app/Http/Controllers/Api/RecordingController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Services\Telephony\RecordingService;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -19,7 +20,7 @@ class RecordingController extends Controller
         $result = $service->startRecording(
             $request->user(),
             $this->campaign($request, $validated),
-            $validated['stage'] ?? null
+            $validated['stage'] ?? null,
         );
 
         return $this->respond($result);
@@ -50,7 +51,12 @@ class RecordingController extends Controller
 
     protected function campaign(Request $request, array $validated = []): string
     {
-        return (string) ($validated['campaign'] ?? $request->input('campaign', $request->session()->get('campaign', 'mbsales')));
+        $explicit = $validated['campaign'] ?? $request->input('campaign');
+
+        return TelephonyCampaignResolver::resolve(
+            $request,
+            is_string($explicit) && $explicit !== '' ? $explicit : null,
+        );
     }
 
     protected function respond($result): JsonResponse

--- a/app/Http/Controllers/Api/ReportingController.php
+++ b/app/Http/Controllers/Api/ReportingController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Services\Telephony\ReportingService;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -67,7 +68,12 @@ class ReportingController extends Controller
 
     protected function campaign(Request $request): string
     {
-        return (string) $request->input('campaign', $request->session()->get('campaign', 'mbsales'));
+        $explicit = $request->input('campaign');
+
+        return TelephonyCampaignResolver::resolve(
+            $request,
+            is_string($explicit) && $explicit !== '' ? (string) $explicit : null,
+        );
     }
 
     protected function respond($result): JsonResponse

--- a/app/Http/Controllers/Api/SupervisorTelephonyController.php
+++ b/app/Http/Controllers/Api/SupervisorTelephonyController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use App\Services\Telephony\VicidialProxyService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -11,7 +12,7 @@ use Illuminate\Http\Request;
 class SupervisorTelephonyController extends Controller
 {
     public function __construct(
-        protected VicidialProxyService $agentApi
+        protected VicidialProxyService $agentApi,
     ) {}
 
     public function monitor(Request $request): JsonResponse
@@ -43,12 +44,16 @@ class SupervisorTelephonyController extends Controller
             'show_confetti' => ['nullable', 'boolean'],
         ]);
 
-        $campaign = (string) $request->input('campaign', $request->session()->get('campaign', 'mbsales'));
+        $explicit = $request->input('campaign');
+        $campaign = TelephonyCampaignResolver::resolve(
+            $request,
+            is_string($explicit) && $explicit !== '' ? (string) $explicit : null,
+        );
         $payload = [
             'recipient_type' => $validated['recipient_type'],
             'recipient' => $validated['recipient'],
             'notification_text' => $validated['notification_text'] ?? '',
-            'show_confetti' => !empty($validated['show_confetti']) ? 'Y' : 'N',
+            'show_confetti' => ! empty($validated['show_confetti']) ? 'Y' : 'N',
         ];
 
         $result = $this->agentApi->execute($request->user(), $campaign, 'send_notification', [
@@ -73,7 +78,7 @@ class SupervisorTelephonyController extends Controller
             'server_ip' => ['nullable', 'string', 'max:20'],
         ]);
 
-        $campaign = (string) ($validated['campaign'] ?? $request->session()->get('campaign', 'mbsales'));
+        $campaign = TelephonyCampaignResolver::resolve($request, $validated['campaign'] ?? null);
         $agent = User::findOrFail((int) $validated['agent_user_id']);
 
         $query = array_merge([

--- a/app/Http/Controllers/Api/TransferController.php
+++ b/app/Http/Controllers/Api/TransferController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use App\Services\Telephony\TransferService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -15,6 +16,7 @@ class TransferController extends Controller
             'phone_number' => ['required', 'string', 'max:50'],
             'campaign' => ['nullable', 'string', 'max:50'],
         ]);
+
         return $this->respond($service->blindTransfer($request->user(), $this->campaign($request, $validated), $validated['phone_number']));
     }
 
@@ -32,7 +34,7 @@ class TransferController extends Controller
             $this->campaign($request, $validated),
             $validated['phone_number'] ?? null,
             $validated['ingroup'] ?? null,
-            (bool) ($validated['consultative'] ?? true)
+            (bool) ($validated['consultative'] ?? true),
         ));
     }
 
@@ -48,7 +50,7 @@ class TransferController extends Controller
             $request->user(),
             $this->campaign($request, $validated),
             $validated['ingroup'],
-            $validated['phone_number'] ?? null
+            $validated['phone_number'] ?? null,
         ));
     }
 
@@ -96,13 +98,18 @@ class TransferController extends Controller
         return $this->respond($service->swapPark(
             $request->user(),
             $this->campaign($request),
-            strtoupper($validated['target'])
+            strtoupper($validated['target']),
         ));
     }
 
     protected function campaign(Request $request, array $validated = []): string
     {
-        return (string) ($validated['campaign'] ?? $request->input('campaign', $request->session()->get('campaign', 'mbsales')));
+        $explicit = $validated['campaign'] ?? $request->input('campaign');
+
+        return TelephonyCampaignResolver::resolve(
+            $request,
+            is_string($explicit) && $explicit !== '' ? $explicit : null,
+        );
     }
 
     protected function respond($result): JsonResponse

--- a/app/Http/Controllers/Api/VicidialProxyController.php
+++ b/app/Http/Controllers/Api/VicidialProxyController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Services\Telephony\CallOrchestrationService;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use App\Services\Telephony\VicidialProxyService;
 use App\Support\CallErrors;
 use Illuminate\Http\JsonResponse;
@@ -17,7 +18,7 @@ class VicidialProxyController extends Controller
         if (empty($action)) {
             return response()->json(['success' => false, 'message' => 'Missing action']);
         }
-        $campaign = $request->query('campaign') ?: $request->session()->get('campaign', 'mbsales');
+        $campaign = $request->query('campaign') ?: TelephonyCampaignResolver::forRequest($request);
 
         // Dial actions: delegate to CallOrchestrationService (creates session, state machine)
         $dialActions = ['originate', 'external_dial'];

--- a/app/Http/Controllers/Api/VicidialSessionController.php
+++ b/app/Http/Controllers/Api/VicidialSessionController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use App\Services\Telephony\VicidialAgentCampaignsService;
 use App\Services\Telephony\VicidialSessionService;
 use Illuminate\Http\JsonResponse;
@@ -24,7 +25,7 @@ class VicidialSessionController extends Controller
         ]);
 
         $user = $request->user();
-        $campaign = $validated['campaign'] ?? $request->session()->get('campaign', 'mbsales');
+        $campaign = TelephonyCampaignResolver::resolve($request, $validated['campaign'] ?? null);
 
         $result = $service->loginAgent(
             $user,
@@ -65,7 +66,7 @@ class VicidialSessionController extends Controller
             'campaign' => ['nullable', 'string', 'max:50'],
         ]);
 
-        $campaign = $validated['campaign'] ?? $request->session()->get('campaign', 'mbsales');
+        $campaign = TelephonyCampaignResolver::resolve($request, $validated['campaign'] ?? null);
         $user = $request->user();
         $session = $service->getLocalSession($user, $campaign);
         $creds = $service->resolveEffectivePhoneCredentials($user, $session->phone_login, null);
@@ -96,7 +97,12 @@ class VicidialSessionController extends Controller
      */
     public function verify(Request $request, VicidialSessionService $service): JsonResponse
     {
-        $campaign = (string) $request->input('campaign', $request->session()->get('campaign', 'mbsales'));
+        $campaign = TelephonyCampaignResolver::resolve(
+            $request,
+            $request->input('campaign') !== null && $request->input('campaign') !== ''
+                ? (string) $request->input('campaign')
+                : null,
+        );
         $result = $service->verifyLogin($request->user(), $campaign);
 
         return response()->json([
@@ -114,7 +120,7 @@ class VicidialSessionController extends Controller
             'value' => ['required', 'string', 'in:PAUSE,RESUME,pause,resume'],
         ]);
 
-        $campaign = $validated['campaign'] ?? $request->session()->get('campaign', 'mbsales');
+        $campaign = TelephonyCampaignResolver::resolve($request, $validated['campaign'] ?? null);
         $result = $service->pauseAgent($request->user(), $campaign, strtoupper($validated['value']));
 
         return response()->json([
@@ -131,7 +137,7 @@ class VicidialSessionController extends Controller
             'pause_code' => ['required', 'string', 'max:6'],
         ]);
 
-        $campaign = $validated['campaign'] ?? $request->session()->get('campaign', 'mbsales');
+        $campaign = TelephonyCampaignResolver::resolve($request, $validated['campaign'] ?? null);
         $result = $service->setPauseCode($request->user(), $campaign, $validated['pause_code']);
 
         return response()->json([
@@ -143,7 +149,12 @@ class VicidialSessionController extends Controller
 
     public function logout(Request $request, VicidialSessionService $service): JsonResponse
     {
-        $campaign = (string) $request->input('campaign', $request->session()->get('campaign', 'mbsales'));
+        $campaign = TelephonyCampaignResolver::resolve(
+            $request,
+            $request->input('campaign') !== null && $request->input('campaign') !== ''
+                ? (string) $request->input('campaign')
+                : null,
+        );
         $result = $service->logoutAgent($request->user(), $campaign);
 
         return response()->json([
@@ -155,7 +166,12 @@ class VicidialSessionController extends Controller
 
     public function status(Request $request, VicidialSessionService $service): JsonResponse
     {
-        $campaign = (string) $request->input('campaign', $request->session()->get('campaign', 'mbsales'));
+        $campaign = TelephonyCampaignResolver::resolve(
+            $request,
+            $request->input('campaign') !== null && $request->input('campaign') !== ''
+                ? (string) $request->input('campaign')
+                : null,
+        );
         $status = $service->getAgentStatus($request->user(), $campaign);
         $queue = $service->getCallsInQueue($request->user(), $campaign);
         $ingroups = $service->getAgentInGroupInfo($request->user(), $campaign);
@@ -194,7 +210,7 @@ class VicidialSessionController extends Controller
             'blended' => ['nullable', 'boolean'],
         ]);
 
-        $campaign = $validated['campaign'] ?? $request->session()->get('campaign', 'mbsales');
+        $campaign = TelephonyCampaignResolver::resolve($request, $validated['campaign'] ?? null);
         $result = $service->changeIngroups(
             $request->user(),
             $campaign,
@@ -242,7 +258,7 @@ class VicidialSessionController extends Controller
     }
 
     /**
-     * Persist selected campaign to the Laravel session (dial, iframe VD_campaign, etc.).
+     * Persist softphone (VICIdial) campaign only — does not change CRM session('campaign').
      */
     public function selectCampaign(Request $request): JsonResponse
     {
@@ -251,9 +267,9 @@ class VicidialSessionController extends Controller
             'campaign_name' => ['nullable', 'string', 'max:255'],
         ]);
 
-        $request->session()->put('campaign', $validated['campaign']);
+        $request->session()->put('vicidial_campaign', $validated['campaign']);
         $request->session()->put(
-            'campaign_name',
+            'vicidial_campaign_name',
             $validated['campaign_name'] ?? $validated['campaign'],
         );
 

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -120,9 +120,23 @@ class LoginController extends Controller
         $this->authService->logAttendance($user->id, 'login', $request->ip());
 
         $campaigns = $this->campaignService->getCampaigns();
-        if ($campaign && isset($campaigns[$campaign])) {
-            $request->session()->put('campaign', $campaign);
-            $request->session()->put('campaign_name', $campaigns[$campaign]['name'] ?? $campaign);
+        $resolved = null;
+        if (is_string($campaign) && $campaign !== '') {
+            if (isset($campaigns[$campaign])) {
+                $resolved = $campaign;
+            } else {
+                foreach (array_keys($campaigns) as $key) {
+                    if (strcasecmp((string) $key, $campaign) === 0) {
+                        $resolved = $key;
+
+                        break;
+                    }
+                }
+            }
+        }
+        if ($resolved !== null) {
+            $request->session()->put('campaign', $resolved);
+            $request->session()->put('campaign_name', $campaigns[$resolved]['name'] ?? $resolved);
         } else {
             $first = array_key_first($campaigns);
             if ($first) {

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Repositories\AttendanceRepository;
 use App\Repositories\UserRepository;
 use App\Services\Telephony\CallOrchestrationService;
+use App\Services\Telephony\TelephonyCampaignResolver;
 use App\Services\Telephony\VicidialSessionService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -76,7 +77,7 @@ class AuthService
         $sessionId = $request->session()->getId();
 
         $user = Auth::user();
-        $campaign = (string) $request->session()->get('campaign', 'mbsales');
+        $campaign = TelephonyCampaignResolver::forRequest($request);
         if ($user) {
             $this->callOrchestration->forceCompleteAllForUser($user);
 

--- a/app/Services/Telephony/TelephonyBootstrapService.php
+++ b/app/Services/Telephony/TelephonyBootstrapService.php
@@ -32,10 +32,12 @@ class TelephonyBootstrapService
         }
 
         $campaigns = $this->campaignService->getCampaigns();
-        $sessionCampaign = $request->session()->get('campaign');
+        $candidate = $request->session()->get('vicidial_campaign')
+            ?? $request->session()->get('campaign');
+        $sessionCampaign = is_string($candidate) && $candidate !== '' ? $candidate : null;
 
         $campaign = null;
-        if (is_string($sessionCampaign) && $sessionCampaign !== '' && isset($campaigns[$sessionCampaign])) {
+        if ($sessionCampaign !== null && isset($campaigns[$sessionCampaign])) {
             $campaign = $sessionCampaign;
         } elseif (is_string($user->default_campaign) && $user->default_campaign !== '' && isset($campaigns[$user->default_campaign])) {
             $campaign = $user->default_campaign;

--- a/app/Services/Telephony/TelephonyCampaignResolver.php
+++ b/app/Services/Telephony/TelephonyCampaignResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Services\Telephony;
+
+use Illuminate\Http\Request;
+
+/**
+ * VICIdial / dialer campaign is stored separately from CRM session('campaign') so the softphone
+ * does not overwrite the user's login campaign (forms, records, dispositions, etc.).
+ */
+final class TelephonyCampaignResolver
+{
+    /**
+     * Softphone-selected campaign, or CRM campaign when the user has not chosen a dialer campaign.
+     */
+    public static function forRequest(Request $request): string
+    {
+        $crm = (string) $request->session()->get('campaign', 'mbsales');
+        $vic = $request->session()->get('vicidial_campaign');
+
+        return (is_string($vic) && $vic !== '') ? $vic : $crm;
+    }
+
+    /**
+     * Prefer an explicit campaign from query/body when non-empty; otherwise session telephony default.
+     */
+    public static function resolve(Request $request, ?string $explicit): string
+    {
+        if (is_string($explicit) && $explicit !== '') {
+            return $explicit;
+        }
+
+        return self::forRequest($request);
+    }
+}

--- a/resources/js/phone-widget.js
+++ b/resources/js/phone-widget.js
@@ -2,6 +2,25 @@
  * Global floating phone / VICIdial session widget (see resources/views/partials/phone-widget.blade.php).
  * `window.__VICIDIAL_SESSION_IFRAME_ONLY` is set inline in the Blade partial before Alpine inits.
  */
+
+/**
+ * Match CRM campaign code to a row from VICIdial (exact id, then case-insensitive).
+ * @param {Array<{id: string, name?: string}>} agentCampaigns
+ * @param {string} crmCode
+ * @returns {{id: string, name?: string}|null}
+ */
+function findCampaignInAgentList(agentCampaigns, crmCode) {
+    if (!crmCode || !Array.isArray(agentCampaigns) || agentCampaigns.length === 0) {
+        return null;
+    }
+    const exact = agentCampaigns.find((c) => c && c.id === crmCode);
+    if (exact) {
+        return exact;
+    }
+    const lower = String(crmCode).toLowerCase();
+    return agentCampaigns.find((c) => c && String(c.id).toLowerCase() === lower) || null;
+}
+
 window.getPhoneWidgetCtx = function getPhoneWidgetCtx() {
     const el = document.getElementById('phone-widget-root');
     if (!el || !window.Alpine?.$data) {
@@ -47,8 +66,9 @@ window.phoneWidget = function phoneWidget(boot = {}) {
                 .filter(Boolean);
         },
 
-        currentCampaign() {
-            const fromBody = document.body?.dataset?.campaign;
+        /** VICIdial / dialer campaign only — never reads CRM `data-campaign`. */
+        telephonyCampaign() {
+            const fromBody = document.body?.dataset?.telephonyCampaign;
             return this.vici.vici_campaign || fromBody || 'mbsales';
         },
 
@@ -60,7 +80,7 @@ window.phoneWidget = function phoneWidget(boot = {}) {
                     campaign: code,
                     campaign_name: row?.name || code,
                 });
-                if (document.body?.dataset) document.body.dataset.campaign = code;
+                if (document.body?.dataset) document.body.dataset.telephonyCampaign = code;
                 Alpine.store('vicidial').campaign = code;
             } catch (_) {}
         },
@@ -75,16 +95,32 @@ window.phoneWidget = function phoneWidget(boot = {}) {
             this.vici.agent_campaigns_error = null;
             try {
                 const res = await window.axios.get('/api/vicidial/session/agent-campaigns', {
-                    params: { context_campaign: this.currentCampaign() },
+                    params: { context_campaign: this.telephonyCampaign() },
                 });
                 if (res.data?.success && Array.isArray(res.data.campaigns)) {
                     this.vici.agent_campaigns = res.data.campaigns;
-                    const ids = this.vici.agent_campaigns.map((c) => c.id);
-                    if (ids.length && !ids.includes(this.vici.vici_campaign)) {
-                        this.vici.vici_campaign = this.vici.agent_campaigns[0].id;
-                        await this.persistViciCampaignToSession();
+                    const crmCode = this.vici.vici_campaign;
+                    const match = findCampaignInAgentList(this.vici.agent_campaigns, crmCode);
+
+                    if (match) {
+                        // Align softphone state + session vicidial_* to VICIdial canonical id (e.g. casing).
+                        if (match.id !== crmCode) {
+                            this.vici.vici_campaign = match.id;
+                            await this.persistViciCampaignToSession();
+                        } else if (document.body?.dataset) {
+                            document.body.dataset.telephonyCampaign = match.id;
+                        }
+                    } else if (this.vici.agent_campaigns.length && crmCode) {
+                        // Softphone campaign not in API list: keep selection, prepend for the dropdown.
+                        this.vici.agent_campaigns = [
+                            { id: crmCode, name: crmCode },
+                            ...this.vici.agent_campaigns,
+                        ];
+                        if (document.body?.dataset) {
+                            document.body.dataset.telephonyCampaign = crmCode;
+                        }
                     } else if (document.body?.dataset) {
-                        document.body.dataset.campaign = this.vici.vici_campaign;
+                        document.body.dataset.telephonyCampaign = this.vici.vici_campaign;
                     }
                 }
             } catch (e) {
@@ -101,7 +137,7 @@ window.phoneWidget = function phoneWidget(boot = {}) {
                 return;
             }
             await window.VicidialSession.login({
-                campaign: this.currentCampaign(),
+                campaign: this.telephonyCampaign(),
                 phoneLogin: this.vici.phone_login || null,
                 phonePass: this.vici.phone_pass || null,
                 vdLogin: this.vici.vd_login || null,
@@ -115,7 +151,7 @@ window.phoneWidget = function phoneWidget(boot = {}) {
 
         async viciPause(value) {
             if (!this.sessionControls || !window.VicidialSession?.pause) return;
-            await window.VicidialSession.pause(value, this.currentCampaign(), this);
+            await window.VicidialSession.pause(value, this.telephonyCampaign(), this);
         },
 
         /** Pause when active (ready/in_call); "Active" when paused — matches Vicidial wording */
@@ -130,12 +166,12 @@ window.phoneWidget = function phoneWidget(boot = {}) {
 
         async viciLogout() {
             if (!this.sessionControls || !window.VicidialSession?.logout) return;
-            await window.VicidialSession.logout(this.currentCampaign(), this);
+            await window.VicidialSession.logout(this.telephonyCampaign(), this);
         },
 
         async viciPopout() {
             if (!this.sessionControls || !window.VicidialSession?.popout) return;
-            await window.VicidialSession.popout(this.currentCampaign(), this);
+            await window.VicidialSession.popout(this.telephonyCampaign(), this);
         },
 
         _onWsPhase(e) {
@@ -158,9 +194,7 @@ window.phoneWidget = function phoneWidget(boot = {}) {
 
             let viciStatusData = null;
             try {
-                viciStatusData = await Alpine.store('vicidial').sync(
-                    document.body.dataset.campaign || 'mbsales',
-                );
+                viciStatusData = await Alpine.store('vicidial').sync(this.telephonyCampaign());
             } catch (_) {}
 
             try {
@@ -168,7 +202,7 @@ window.phoneWidget = function phoneWidget(boot = {}) {
                 if (window.VicidialSession?.maybeReconnectPending) {
                     reconnected = await window.VicidialSession.maybeReconnectPending(
                         viciStatusData?.local_session,
-                        document.body.dataset.campaign,
+                        this.telephonyCampaign(),
                         this,
                     );
                 }
@@ -198,7 +232,7 @@ window.phoneWidget = function phoneWidget(boot = {}) {
         async syncVicidialStatusFromPhone() {
             if (!this.sessionControls) return;
             try {
-                const data = await Alpine.store('vicidial').sync(this.currentCampaign());
+                const data = await Alpine.store('vicidial').sync(this.telephonyCampaign());
                 const localStatus = data?.local_session?.session_status || '';
                 if (['ready', 'paused', 'in_call'].includes(localStatus)) {
                     if (!['syncing', 'iframe_loading', 'requesting'].includes(this.vici.phase)) {

--- a/resources/js/soft-navigate.js
+++ b/resources/js/soft-navigate.js
@@ -10,6 +10,59 @@ function removeInjectedPageScripts() {
     document.querySelectorAll('script[data-soft-nav-injected]').forEach((el) => el.remove());
 }
 
+/**
+ * Normalize href for matching (sidebar links may be absolute or root-relative).
+ */
+function normalizeNavHref(href) {
+    if (!href) {
+        return '';
+    }
+    try {
+        const u = new URL(href, window.location.origin);
+
+        return u.pathname + u.search;
+    } catch {
+        return href;
+    }
+}
+
+/**
+ * Soft-nav only swaps #main-layout; the sidebar stays from the first paint.
+ * Copy which `.sidebar-item` links are `active` from the fetched full HTML
+ * so the magenta current-page state matches the new route.
+ */
+function syncSidebarActiveFromFetchedDocument(doc) {
+    const nextSidebar = doc.getElementById('sidebar');
+    const curSidebar = document.getElementById('sidebar');
+    if (!nextSidebar || !curSidebar) {
+        return;
+    }
+
+    /** @type {Map<string, boolean>} */
+    const activeByHref = new Map();
+    nextSidebar.querySelectorAll('a.sidebar-item').forEach((a) => {
+        const href = a.getAttribute('href');
+        if (!href) {
+            return;
+        }
+        activeByHref.set(normalizeNavHref(href), a.classList.contains('active'));
+    });
+
+    curSidebar.querySelectorAll('a.sidebar-item').forEach((a) => {
+        const href = a.getAttribute('href');
+        if (!href) {
+            return;
+        }
+        const key = normalizeNavHref(href);
+        if (!activeByHref.has(key)) {
+            a.classList.remove('active');
+
+            return;
+        }
+        a.classList.toggle('active', activeByHref.get(key) === true);
+    });
+}
+
 function executeScriptsAfterMarker(doc) {
     const marker = doc.getElementById('soft-nav-scripts-marker');
     if (!marker) {
@@ -91,6 +144,8 @@ async function softNavigate(url, { push = true } = {}) {
     removeInjectedPageScripts();
 
     mainLayout.innerHTML = nextMain.innerHTML;
+
+    syncSidebarActiveFromFetchedDocument(doc);
 
     const titleEl = doc.querySelector('title');
     if (titleEl?.textContent) {

--- a/resources/js/vicidial-session.js
+++ b/resources/js/vicidial-session.js
@@ -6,6 +6,7 @@ const DEFAULT_TIMEOUT_MS = 20000;
 const AXIOS_IFRAME_URL_OPTS = {
     validateStatus: (status) => (status >= 200 && status < 300) || status === 422,
 };
+
 function isIframeAgentApiOnly() {
     return window.__VICIDIAL_SESSION_IFRAME_ONLY === true;
 }
@@ -18,7 +19,7 @@ const state = {
 };
 
 function getCampaign(campaign) {
-    return campaign || document.body?.dataset?.campaign || 'mbsales';
+    return campaign || document.body?.dataset?.telephonyCampaign || 'mbsales';
 }
 
 function phaseSet(ctx, phase) {

--- a/resources/views/agent/index.blade.php
+++ b/resources/views/agent/index.blade.php
@@ -385,12 +385,17 @@ window.agentScreen = function() {
             });
         },
 
-        currentCampaign() {
+        /** CRM login campaign — hopper, forms, dispositions, lead tools. */
+        crmCampaign() {
+            return document.body?.dataset?.campaign || this.$el?.dataset?.campaign || 'mbsales';
+        },
+
+        /** VICIdial / dialer campaign — recordings, transfers, callbacks, DTMF, predictive dial. */
+        telephonyCampaign() {
             return (
-                document.body?.dataset?.campaign ||
+                document.body?.dataset?.telephonyCampaign ||
                 Alpine.store('vicidial').campaign ||
-                this.$el?.dataset?.campaign ||
-                'mbsales'
+                this.crmCampaign()
             );
         },
 
@@ -509,7 +514,7 @@ window.agentScreen = function() {
 
         async syncVicidialStatus() {
             try {
-                const data = await Alpine.store('vicidial').sync(this.currentCampaign());
+                const data = await Alpine.store('vicidial').sync(this.telephonyCampaign());
                 const raw = data?.agent_status?.data?.raw_response || '';
 
                 if (!this.sessionId && typeof raw === 'string' && raw.includes('INCALL')) {
@@ -543,7 +548,7 @@ window.agentScreen = function() {
                     action,
                     this.parseIngroups(Alpine.store('vicidial').ingroupsRaw || ''),
                     Alpine.store('vicidial').blended,
-                    this.currentCampaign(),
+                    this.telephonyCampaign(),
                     ctx
                 );
             }
@@ -591,7 +596,7 @@ window.agentScreen = function() {
 
         async transferAction(url, data = {}) {
             try {
-                await window.axios.post(url, { campaign: this.currentCampaign(), ...data });
+                await window.axios.post(url, { campaign: this.telephonyCampaign(), ...data });
                 Alpine.store('toast').success('Transfer action sent.');
             } catch (e) {
                 Alpine.store('toast').error(e.response?.data?.message || 'Transfer action failed.');
@@ -601,7 +606,7 @@ window.agentScreen = function() {
         async startRecording() {
             if (!this.featureEnabled('recording_controls')) return;
             try {
-                const res = await window.axios.post('/api/call/recording/start', { campaign: this.currentCampaign() });
+                const res = await window.axios.post('/api/call/recording/start', { campaign: this.telephonyCampaign() });
                 this.recording.statusText = res.data?.data?.raw_response || 'Recording started.';
                 Alpine.store('toast').success('Recording start sent.');
             } catch (e) {
@@ -612,7 +617,7 @@ window.agentScreen = function() {
         async stopRecording() {
             if (!this.featureEnabled('recording_controls')) return;
             try {
-                const res = await window.axios.post('/api/call/recording/stop', { campaign: this.currentCampaign() });
+                const res = await window.axios.post('/api/call/recording/stop', { campaign: this.telephonyCampaign() });
                 this.recording.statusText = res.data?.data?.raw_response || 'Recording stopped.';
                 Alpine.store('toast').info('Recording stop sent.');
             } catch (e) {
@@ -623,7 +628,7 @@ window.agentScreen = function() {
         async recordingStatus() {
             if (!this.featureEnabled('recording_controls')) return;
             try {
-                const res = await window.axios.get('/api/call/recording/status', { params: { campaign: this.currentCampaign() } });
+                const res = await window.axios.get('/api/call/recording/status', { params: { campaign: this.telephonyCampaign() } });
                 this.recording.statusText = res.data?.data?.raw_response || 'No status';
             } catch (e) {
                 Alpine.store('toast').error(e.response?.data?.message || 'Failed to fetch recording status.');
@@ -636,7 +641,7 @@ window.agentScreen = function() {
             if (!digits) return;
             try {
                 await window.axios.post('/api/call/dtmf', {
-                    campaign: this.currentCampaign(),
+                    campaign: this.telephonyCampaign(),
                     digits,
                 });
                 Alpine.store('toast').info('DTMF sent: ' + digits);
@@ -650,7 +655,7 @@ window.agentScreen = function() {
             if (!this.leadId || !this.callbackForm.datetime) return;
             try {
                 await window.axios.post('/api/callbacks/schedule', {
-                    campaign: this.currentCampaign(),
+                    campaign: this.telephonyCampaign(),
                     lead_id: this.leadId,
                     callback_datetime: this.callbackForm.datetime.replace('T', '+') + ':00',
                     callback_type: this.callbackForm.type,
@@ -668,7 +673,7 @@ window.agentScreen = function() {
             if (!this.leadId) return;
             try {
                 await window.axios.post('/api/callbacks/remove', {
-                    campaign: this.currentCampaign(),
+                    campaign: this.telephonyCampaign(),
                     lead_id: this.leadId,
                 });
                 Alpine.store('toast').info('Callback removed.');
@@ -683,7 +688,7 @@ window.agentScreen = function() {
             try {
                 const res = await window.axios.get('/api/callbacks/info', {
                     params: {
-                        campaign: this.currentCampaign(),
+                        campaign: this.telephonyCampaign(),
                         lead_id: this.leadId,
                     },
                 });
@@ -699,7 +704,7 @@ window.agentScreen = function() {
             try {
                 const res = await window.axios.get('/api/leads/search', {
                     params: {
-                        campaign: this.currentCampaign(),
+                        campaign: this.crmCampaign(),
                         phone_number: this.leadTools.phone_search,
                     },
                 });
@@ -712,7 +717,7 @@ window.agentScreen = function() {
         async loadLeadInfo() {
             if (!this.featureEnabled('lead_tools')) return;
             try {
-                const params = { campaign: this.currentCampaign() };
+                const params = { campaign: this.crmCampaign() };
                 if (this.leadId) params.lead_id = this.leadId;
                 if (!this.leadId && this.leadTools.phone_search) params.phone_number = this.leadTools.phone_search;
                 const res = await window.axios.get('/api/leads/info', { params });
@@ -727,7 +732,7 @@ window.agentScreen = function() {
             if (!this.leadId) return;
             try {
                 const res = await window.axios.post('/api/leads/switch', {
-                    campaign: this.currentCampaign(),
+                    campaign: this.crmCampaign(),
                     lead_id: this.leadId,
                 });
                 this.leadTools.raw = res.data?.data?.raw_response || '';
@@ -747,7 +752,7 @@ window.agentScreen = function() {
             Alpine.store('call').state = 'dialing';
             Alpine.store('call').number = this.phoneNumber;
             try {
-                const campaign = this.currentCampaign();
+                const campaign = this.telephonyCampaign();
                 const res = await window.axios.post('/api/call/dial?campaign=' + encodeURIComponent(campaign), {
                     phone_number: this.phoneNumber,
                     lead_id: this.leadId || null,
@@ -809,7 +814,7 @@ window.agentScreen = function() {
             if (this.loadingNextLead || (this.callState !== 'idle' && this.callState !== 'wrapup')) return;
             this.loadingNextLead = true;
             try {
-                const campaign = this.currentCampaign();
+                const campaign = this.crmCampaign();
                 const res = await window.axios.get('/api/leads/next', { params: { campaign } });
                 if (res.data.lead) {
                     this.leadId = res.data.lead.lead_id || '';
@@ -831,7 +836,7 @@ window.agentScreen = function() {
             if (!this.dispositionCode) return;
             this.savingDisposition = true;
             this.dispositionError = null;
-            const campaign = this.currentCampaign();
+            const campaign = this.crmCampaign();
             try {
                 await window.axios.post('/api/disposition/save', {
                     campaign_code:    campaign,
@@ -906,7 +911,7 @@ window.agentScreen = function() {
             if (!this.featureEnabled('predictive_dialing')) return;
             if (!this.predictiveMode || this.callState !== 'idle' || this.dialBlocked) return;
             try {
-                const campaign = this.currentCampaign();
+                const campaign = this.telephonyCampaign();
                 const res = await window.axios.post('/api/call/predictive-dial?campaign=' + encodeURIComponent(campaign));
                 if (!res.data.success) {
                     Alpine.store('toast').warning(res.data.message || 'Predictive dial failed.');
@@ -940,7 +945,7 @@ window.agentScreen = function() {
             });
             try {
                 await window.axios.post('/api/agent/capture', {
-                    campaign_code: this.currentCampaign(),
+                    campaign_code: this.crmCampaign(),
                     call_session_id: this.sessionId,
                     lead_id: this.leadId,
                     phone_number: this.phoneNumber,

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -18,7 +18,9 @@
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     @stack('styles')
 </head>
-<body class="min-h-screen flex" style="margin: 0;" x-data x-cloak data-campaign="{{ session('campaign', 'mbsales') }}">
+<body class="min-h-screen flex" style="margin: 0;" x-data x-cloak
+      data-campaign="{{ session('campaign', 'mbsales') }}"
+      data-telephony-campaign="{{ session('vicidial_campaign') ?? session('campaign', 'mbsales') }}">
 
     {{-- Mobile sidebar overlay --}}
     <div x-show="$store.sidebar.mobileOpen"

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -1,8 +1,29 @@
 @php
-    $currentRoute = request()->route()?->getName() ?? '';
     $campaignName = session('campaign_name', 'CRM');
     $campaign     = session('campaign', '');
     $forms        = $campaignConfig['forms'] ?? [];
+    /** Route `forms/{type}` — use route param for active state. */
+    $formsRouteType = request()->route('type');
+
+    /**
+     * Active nav item: exact route name, or `admin.foo.*`-style group when the sidebar points at `admin.foo.index`.
+     * Uses request()->routeIs() so matching stays aligned with Laravel's route naming.
+     */
+    $sidebarLinkActive = static function (string $itemRoute): bool {
+        if ($itemRoute === '' || ! request()->route()) {
+            return false;
+        }
+        if (request()->routeIs($itemRoute)) {
+            return true;
+        }
+        if (str_ends_with($itemRoute, '.index')) {
+            $base = substr($itemRoute, 0, -strlen('.index'));
+
+            return request()->routeIs($base.'.*');
+        }
+
+        return false;
+    };
 
     $navItems = [
         ['route' => 'dashboard',    'label' => 'Dashboard',    'icon' => 'chart-bar'],
@@ -64,7 +85,7 @@
         {{-- Main --}}
         @foreach($navItems as $item)
             <a href="{{ route($item['route']) }}"
-               class="sidebar-item {{ $currentRoute === $item['route'] ? 'active' : '' }}"
+               class="sidebar-item {{ $sidebarLinkActive($item['route']) ? 'active' : '' }}"
                title="{{ $item['label'] }}"
                @click="$store.sidebar.closeMobile()">
                 <x-icon :name="$item['icon']" class="sidebar-icon shrink-0" />
@@ -76,7 +97,7 @@
         <div class="sidebar-section-label">Telephony</div>
         @foreach($telephonyItems as $item)
             <a href="{{ route($item['route']) }}"
-               class="sidebar-item {{ $currentRoute === $item['route'] ? 'active' : '' }}"
+               class="sidebar-item {{ $sidebarLinkActive($item['route']) ? 'active' : '' }}"
                title="{{ $item['label'] }}"
                @click="$store.sidebar.closeMobile()">
                 <x-icon :name="$item['icon']" class="sidebar-icon shrink-0" />
@@ -89,7 +110,7 @@
         <div class="sidebar-section-label">Campaign Forms</div>
         @foreach($forms as $formCode => $formConfig)
             <a href="{{ route('forms.show', ['type' => $formCode, 'campaign' => $campaign]) }}"
-               class="sidebar-item {{ ($currentRoute === 'forms.show' && request('type') === $formCode) ? 'active' : '' }}"
+               class="sidebar-item {{ (request()->routeIs('forms.show') && (string) $formsRouteType === (string) $formCode) ? 'active' : '' }}"
                title="{{ $formConfig['name'] ?? $formCode }}"
                @click="$store.sidebar.closeMobile()">
                 <x-icon name="document-text" class="sidebar-icon shrink-0" />
@@ -103,7 +124,7 @@
         <div class="sidebar-section-label">Admin</div>
         @foreach($adminItems as $item)
             <a href="{{ route($item['route']) }}"
-               class="sidebar-item {{ str_starts_with($currentRoute, str_replace('.index', '', $item['route'])) ? 'active' : '' }}"
+               class="sidebar-item {{ $sidebarLinkActive($item['route']) ? 'active' : '' }}"
                title="{{ $item['label'] }}"
                @click="$store.sidebar.closeMobile()">
                 <x-icon :name="$item['icon']" class="sidebar-icon shrink-0" />
@@ -116,7 +137,7 @@
             <div class="sidebar-section-label">Super Admin</div>
             @foreach($superAdminItems as $item)
                 <a href="{{ route($item['route']) }}"
-                   class="sidebar-item {{ str_starts_with($currentRoute, str_replace(['.index', '.create'], '', $item['route'])) ? 'active' : '' }}"
+                   class="sidebar-item {{ $sidebarLinkActive($item['route']) ? 'active' : '' }}"
                    title="{{ $item['label'] }}"
                    @click="$store.sidebar.closeMobile()">
                     <x-icon :name="$item['icon']" class="sidebar-icon shrink-0" />

--- a/resources/views/partials/phone-widget.blade.php
+++ b/resources/views/partials/phone-widget.blade.php
@@ -3,7 +3,7 @@
 </script>
 @php
     $phoneWidgetBoot = [
-        'vici_campaign' => (string) session('campaign', 'mbsales'),
+        'vici_campaign' => (string) (session('vicidial_campaign') ?? session('campaign', 'mbsales')),
         'phone_login' => (string) (auth()->user()->extension ?? ''),
         'vd_login' => (string) (auth()->user()->vici_user ?? ''),
         'panelW' => (int) config('vicidial.session_iframe_panel_width_px', 440),

--- a/resources/views/reports/index.blade.php
+++ b/resources/views/reports/index.blade.php
@@ -33,25 +33,29 @@
         </div>
     </div>
 
-    <div class="flex gap-2 border-b border-[var(--color-border)]">
-        <button class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+    <div class="flex gap-2 border-b border-[var(--color-border)]" role="tablist">
+        <button type="button" role="tab" :aria-selected="tab === 'status'"
+                class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
                 :class="tab === 'status' ? 'border-[var(--color-primary)] text-[var(--color-primary)]' : 'border-transparent text-[var(--color-on-surface-muted)]'"
-                @click="tab = 'status'">
+                @click="setTab('status')">
             Call Status Stats
         </button>
-        <button class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+        <button type="button" role="tab" :aria-selected="tab === 'agents'"
+                class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
                 :class="tab === 'agents' ? 'border-[var(--color-primary)] text-[var(--color-primary)]' : 'border-transparent text-[var(--color-on-surface-muted)]'"
-                @click="tab = 'agents'">
+                @click="setTab('agents')">
             Agent Performance
         </button>
-        <button class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+        <button type="button" role="tab" :aria-selected="tab === 'dispo'"
+                class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
                 :class="tab === 'dispo' ? 'border-[var(--color-primary)] text-[var(--color-primary)]' : 'border-transparent text-[var(--color-on-surface-muted)]'"
-                @click="tab = 'dispo'">
+                @click="setTab('dispo')">
             Disposition Report
         </button>
-        <button class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
+        <button type="button" role="tab" :aria-selected="tab === 'recording'"
+                class="px-4 py-2 text-sm font-medium border-b-2 transition-colors"
                 :class="tab === 'recording' ? 'border-[var(--color-primary)] text-[var(--color-primary)]' : 'border-transparent text-[var(--color-on-surface-muted)]'"
-                @click="tab = 'recording'">
+                @click="setTab('recording')">
             Recording Browser
         </button>
     </div>
@@ -66,6 +70,8 @@
 @push('scripts')
 <script>
 window.telephonyReports = function () {
+    const ALLOWED_TABS = ['status', 'agents', 'dispo', 'recording'];
+
     return {
         tab: 'status',
         loading: false,
@@ -87,7 +93,26 @@ window.telephonyReports = function () {
         },
 
         init() {
+            this.syncTabFromUrl();
+            this._onPopState = () => this.syncTabFromUrl();
+            window.addEventListener('popstate', this._onPopState);
             this.refreshAll();
+        },
+
+        syncTabFromUrl() {
+            const params = new URLSearchParams(window.location.search);
+            const t = params.get('tab');
+            this.tab = t && ALLOWED_TABS.includes(t) ? t : 'status';
+        },
+
+        setTab(name) {
+            if (!ALLOWED_TABS.includes(name)) {
+                return;
+            }
+            this.tab = name;
+            const url = new URL(window.location.href);
+            url.searchParams.set('tab', name);
+            window.history.replaceState({}, '', url);
         },
 
         async refreshAll() {

--- a/tests/Feature/Api/VicidialSessionApiTest.php
+++ b/tests/Feature/Api/VicidialSessionApiTest.php
@@ -612,7 +612,9 @@ class VicidialSessionApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('success', true);
 
-        $this->assertSame('newcamp', session('campaign'));
-        $this->assertSame('New Camp', session('campaign_name'));
+        $this->assertSame('newcamp', session('vicidial_campaign'));
+        $this->assertSame('New Camp', session('vicidial_campaign_name'));
+        $this->assertSame('testcamp', session('campaign'));
+        $this->assertSame('Test', session('campaign_name'));
     }
 }


### PR DESCRIPTION
…ght on soft nav

- Add TelephonyCampaignResolver and use vicidial_campaign for dialer APIs; CRM session campaign unchanged for hopper and lead tools
- Store softphone campaign only in selectCampaign; login resolves campaign case-insensitively
- Sidebar: use routeIs() for active links; sync .active after soft navigation (main-layout swap)
- Phone widget and agent screen: crmCampaign vs telephonyCampaign; dataset telephonyCampaign