### PR TITLE
Attendance status

### DIFF
--- a/app/Contracts/Repositories/AttendanceRepositoryInterface.php
+++ b/app/Contracts/Repositories/AttendanceRepositoryInterface.php
@@ -9,7 +9,20 @@ interface AttendanceRepositoryInterface
 {
     public function log(int $userId, string $eventType, ?string $ipAddress = null): AttendanceLog;
 
-    public function getLogs(?int $userId = null, ?string $date = null, int $limit = 50): Collection;
+    public function logCustomEvent(
+        int $userId,
+        string $eventType,
+        int $attendanceStatusTypeId,
+        string $direction,
+        ?string $ipAddress = null,
+    ): AttendanceLog;
+
+    public function getLogs(
+        ?int $userId = null,
+        ?string $date = null,
+        int $limit = 50,
+        ?string $eventFilter = null,
+    ): Collection;
 
     public function getLastEvent(int $userId): ?AttendanceLog;
 }

--- a/app/Http/Controllers/Admin/AttendanceLogsController.php
+++ b/app/Http/Controllers/Admin/AttendanceLogsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\AttendanceStatusType;
 use App\Repositories\AttendanceRepository;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -10,16 +11,23 @@ use Illuminate\View\View;
 class AttendanceLogsController extends Controller
 {
     public function __construct(
-        protected AttendanceRepository $attendanceRepository
+        protected AttendanceRepository $attendanceRepository,
     ) {}
 
     public function index(Request $request): View
     {
         $userId = $request->query('user_id') ? (int) $request->query('user_id') : null;
         $date = $request->query('date');
-        $logs = $this->attendanceRepository->getLogs($userId, $date, 100);
+        $event = $request->query('event');
+        $eventFilter = is_string($event) && $event !== '' ? $event : null;
+        $logs = $this->attendanceRepository->getLogs($userId, $date, 100, $eventFilter);
+
         return view('admin.attendance_logs', [
             'logs' => $logs,
+            'statusTypes' => AttendanceStatusType::query()
+                ->orderBy('sort_order')
+                ->orderBy('id')
+                ->get(),
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/AttendanceStatusTypesController.php
+++ b/app/Http/Controllers/Admin/AttendanceStatusTypesController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\AttendanceStatusType;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+
+class AttendanceStatusTypesController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $types = AttendanceStatusType::query()
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
+
+        return view('admin.attendance_status_types', [
+            'types' => $types,
+            'campaignName' => $request->session()->get('campaign_name', 'CRM'),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'code' => ['required', 'string', 'max:30', 'regex:/^[a-z0-9_]+$/', 'unique:attendance_status_types,code'],
+            'label' => ['required', 'string', 'max:60'],
+            'sort_order' => ['nullable', 'integer', 'min:0', 'max:65535'],
+        ]);
+
+        AttendanceStatusType::create([
+            'code' => $validated['code'],
+            'label' => $validated['label'],
+            'sort_order' => $validated['sort_order'] ?? 0,
+            'is_active' => true,
+        ]);
+
+        return redirect()->route('admin.attendance-statuses.index')
+            ->with('success', __('Attendance status created.'));
+    }
+
+    public function update(Request $request, int $id): RedirectResponse
+    {
+        $type = AttendanceStatusType::findOrFail($id);
+
+        $validated = $request->validate([
+            'code' => [
+                'required',
+                'string',
+                'max:30',
+                'regex:/^[a-z0-9_]+$/',
+                Rule::unique('attendance_status_types', 'code')->ignore($type->id),
+            ],
+            'label' => ['required', 'string', 'max:60'],
+            'sort_order' => ['nullable', 'integer', 'min:0', 'max:65535'],
+            'is_active' => ['sometimes', 'boolean'],
+        ]);
+
+        $type->update([
+            'code' => $validated['code'],
+            'label' => $validated['label'],
+            'sort_order' => $validated['sort_order'] ?? $type->sort_order,
+            'is_active' => $request->boolean('is_active', $type->is_active),
+        ]);
+
+        return redirect()->route('admin.attendance-statuses.index')
+            ->with('success', __('Attendance status updated.'));
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        $id = (int) $request->input('id');
+        $type = AttendanceStatusType::findOrFail($id);
+        $type->update(['is_active' => false]);
+
+        return redirect()->route('admin.attendance-statuses.index')
+            ->with('success', __('Attendance status deactivated.'));
+    }
+}

--- a/app/Http/Controllers/Api/AttendanceStatusController.php
+++ b/app/Http/Controllers/Api/AttendanceStatusController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AttendanceStatusType;
+use App\Services\AttendanceStatusService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class AttendanceStatusController extends Controller
+{
+    public function __construct(
+        protected AttendanceStatusService $attendanceStatusService,
+    ) {}
+
+    public function start(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'code' => ['required', 'string', 'max:30'],
+        ]);
+
+        try {
+            $log = $this->attendanceStatusService->startStatus(
+                $request->user(),
+                $validated['code'],
+                $request->ip(),
+            );
+        } catch (ValidationException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => collect($e->errors())->flatten()->first() ?? 'Validation failed.',
+                'errors' => $e->errors(),
+            ], 422);
+        }
+
+        $log->load('statusType');
+
+        return response()->json([
+            'success' => true,
+            'log' => [
+                'id' => $log->id,
+                'event_type' => $log->event_type,
+                'direction' => $log->direction,
+                'event_time' => $log->event_time?->toIso8601String(),
+                'status_label' => $log->statusType?->label,
+            ],
+        ]);
+    }
+
+    public function end(Request $request): JsonResponse
+    {
+        try {
+            $log = $this->attendanceStatusService->endStatus($request->user(), $request->ip());
+        } catch (ValidationException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => collect($e->errors())->flatten()->first() ?? 'Validation failed.',
+                'errors' => $e->errors(),
+            ], 422);
+        }
+
+        $log->load('statusType');
+
+        return response()->json([
+            'success' => true,
+            'log' => [
+                'id' => $log->id,
+                'event_type' => $log->event_type,
+                'direction' => $log->direction,
+                'event_time' => $log->event_time?->toIso8601String(),
+                'status_label' => $log->statusType?->label,
+            ],
+        ]);
+    }
+
+    public function current(Request $request): JsonResponse
+    {
+        $open = $this->attendanceStatusService->getOpenStatus($request->user());
+        if ($open !== null) {
+            $open->load('statusType');
+        }
+
+        $types = AttendanceStatusType::query()
+            ->active()
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get(['id', 'code', 'label', 'sort_order']);
+
+        return response()->json([
+            'success' => true,
+            'open' => $open ? [
+                'id' => $open->id,
+                'code' => $open->statusType?->code,
+                'label' => $open->statusType?->label,
+                'started_at' => $open->event_time?->toIso8601String(),
+                'attendance_status_type_id' => $open->attendance_status_type_id,
+            ] : null,
+            'types' => $types,
+        ]);
+    }
+}

--- a/app/Models/AttendanceLog.php
+++ b/app/Models/AttendanceLog.php
@@ -8,9 +8,17 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class AttendanceLog extends Model
 {
+    public const SYSTEM_EVENT_TYPES = ['login', 'logout'];
+
+    public const DIRECTION_START = 'start';
+
+    public const DIRECTION_END = 'end';
+
     protected $fillable = [
         'user_id',
         'event_type',
+        'attendance_status_type_id',
+        'direction',
         'event_time',
         'ip_address',
     ];
@@ -25,6 +33,31 @@ class AttendanceLog extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function statusType(): BelongsTo
+    {
+        return $this->belongsTo(AttendanceStatusType::class, 'attendance_status_type_id');
+    }
+
+    public function eventDisplayLabel(): string
+    {
+        if (in_array($this->event_type, self::SYSTEM_EVENT_TYPES, true)) {
+            return strtoupper($this->event_type);
+        }
+
+        $base = $this->relationLoaded('statusType') && $this->statusType
+            ? $this->statusType->label
+            : strtoupper($this->event_type);
+
+        if ($this->direction === self::DIRECTION_START) {
+            return $base.' (Start)';
+        }
+        if ($this->direction === self::DIRECTION_END) {
+            return $base.' (End)';
+        }
+
+        return $base;
     }
 
     public function scopeForUser(Builder $query, int $userId): Builder

--- a/app/Models/AttendanceStatusType.php
+++ b/app/Models/AttendanceStatusType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AttendanceStatusType extends Model
+{
+    protected $fillable = [
+        'code',
+        'label',
+        'sort_order',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+            'sort_order' => 'integer',
+        ];
+    }
+
+    public function logs(): HasMany
+    {
+        return $this->hasMany(AttendanceLog::class, 'attendance_status_type_id');
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+}

--- a/app/Repositories/AttendanceRepository.php
+++ b/app/Repositories/AttendanceRepository.php
@@ -18,20 +18,52 @@ class AttendanceRepository implements AttendanceRepositoryInterface
         ]);
     }
 
-    public function getLogs(?int $userId = null, ?string $date = null, int $limit = 50): Collection
-    {
-        $q = AttendanceLog::with('user')->orderByDesc('event_time');
+    public function logCustomEvent(
+        int $userId,
+        string $eventType,
+        int $attendanceStatusTypeId,
+        string $direction,
+        ?string $ipAddress = null,
+    ): AttendanceLog {
+        return AttendanceLog::create([
+            'user_id' => $userId,
+            'event_type' => $eventType,
+            'attendance_status_type_id' => $attendanceStatusTypeId,
+            'direction' => $direction,
+            'event_time' => now(),
+            'ip_address' => $ipAddress,
+        ]);
+    }
+
+    public function getLogs(
+        ?int $userId = null,
+        ?string $date = null,
+        int $limit = 50,
+        ?string $eventFilter = null,
+    ): Collection {
+        $q = AttendanceLog::with(['user', 'statusType'])->orderByDesc('event_time');
         if ($userId !== null) {
             $q->where('user_id', $userId);
         }
         if ($date !== null) {
             $q->whereDate('event_time', $date);
         }
+        if ($eventFilter === 'login') {
+            $q->where('event_type', 'login');
+        } elseif ($eventFilter === 'logout') {
+            $q->where('event_type', 'logout');
+        } elseif ($eventFilter !== null && $eventFilter !== '' && is_numeric($eventFilter)) {
+            $q->where('attendance_status_type_id', (int) $eventFilter);
+        }
+
         return $q->limit($limit)->get();
     }
 
     public function getLastEvent(int $userId): ?AttendanceLog
     {
-        return AttendanceLog::where('user_id', $userId)->orderByDesc('event_time')->first();
+        return AttendanceLog::with('statusType')
+            ->where('user_id', $userId)
+            ->orderByDesc('event_time')
+            ->first();
     }
 }

--- a/app/Services/AttendanceStatusService.php
+++ b/app/Services/AttendanceStatusService.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\Repositories\AttendanceRepositoryInterface;
+use App\Models\AttendanceLog;
+use App\Models\AttendanceStatusType;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class AttendanceStatusService
+{
+    public function __construct(
+        protected AttendanceRepositoryInterface $attendanceRepository,
+    ) {}
+
+    /**
+     * Start a custom attendance segment (e.g. lunch). Only one open segment at a time.
+     */
+    public function startStatus(User $user, string $code, ?string $ip): AttendanceLog
+    {
+        $type = AttendanceStatusType::query()->where('code', $code)->active()->first();
+        if (! $type) {
+            throw ValidationException::withMessages([
+                'code' => [__('Invalid or inactive attendance status.')],
+            ]);
+        }
+
+        if ($this->getOpenStatus($user) !== null) {
+            throw ValidationException::withMessages([
+                'code' => [__('End your current status before starting another.')],
+            ]);
+        }
+
+        $eventType = $type->code.'_'.AttendanceLog::DIRECTION_START;
+
+        return DB::transaction(function () use ($user, $type, $eventType, $ip) {
+            return $this->attendanceRepository->logCustomEvent(
+                $user->id,
+                $eventType,
+                $type->id,
+                AttendanceLog::DIRECTION_START,
+                $ip,
+            );
+        });
+    }
+
+    /**
+     * End the currently open custom segment (same type as the open start).
+     */
+    public function endStatus(User $user, ?string $ip): AttendanceLog
+    {
+        $open = $this->getOpenStatus($user);
+        if ($open === null) {
+            throw ValidationException::withMessages([
+                'status' => [__('No active attendance status to end.')],
+            ]);
+        }
+
+        $type = $open->statusType;
+        if (! $type) {
+            throw ValidationException::withMessages([
+                'status' => [__('Could not resolve attendance status type.')],
+            ]);
+        }
+
+        $eventType = $type->code.'_'.AttendanceLog::DIRECTION_END;
+
+        return DB::transaction(function () use ($user, $type, $eventType, $ip) {
+            return $this->attendanceRepository->logCustomEvent(
+                $user->id,
+                $eventType,
+                $type->id,
+                AttendanceLog::DIRECTION_END,
+                $ip,
+            );
+        });
+    }
+
+    /**
+     * If there is an unmatched start today, return that log row; otherwise null.
+     */
+    public function getOpenStatus(User $user): ?AttendanceLog
+    {
+        $logs = AttendanceLog::query()
+            ->where('user_id', $user->id)
+            ->whereDate('event_time', today())
+            ->whereNotNull('attendance_status_type_id')
+            ->whereNotNull('direction')
+            ->with('statusType')
+            ->orderBy('event_time')
+            ->orderBy('id')
+            ->get();
+
+        $open = null;
+        foreach ($logs as $log) {
+            if ($log->direction === AttendanceLog::DIRECTION_START) {
+                $open = $log;
+            } elseif ($log->direction === AttendanceLog::DIRECTION_END
+                && $open !== null
+                && (int) $log->attendance_status_type_id === (int) $open->attendance_status_type_id) {
+                $open = null;
+            }
+        }
+
+        return $open;
+    }
+
+    /**
+     * Auto-insert end event before logout when a segment is still open.
+     */
+    public function autoCloseOnLogout(User $user, ?string $ip): void
+    {
+        if ($this->getOpenStatus($user) === null) {
+            return;
+        }
+
+        try {
+            $this->endStatus($user, $ip);
+        } catch (ValidationException) {
+            // Should not happen if getOpenStatus matched; ignore to not block logout.
+        }
+    }
+}

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -19,6 +19,7 @@ class AuthService
     public function __construct(
         protected UserRepository $userRepository,
         protected AttendanceRepository $attendanceRepository,
+        protected AttendanceStatusService $attendanceStatusService,
         protected CallOrchestrationService $callOrchestration,
         protected VicidialSessionService $vicidialSessionService,
     ) {}
@@ -87,6 +88,7 @@ class AuthService
                 // Best-effort telephony cleanup; auth logout must still complete.
             }
             DB::transaction(function () use ($user): void {
+                $this->attendanceStatusService->autoCloseOnLogout($user, request()?->ip());
                 $this->attendanceRepository->log($user->id, 'logout', request()?->ip());
                 event(new UserLoggedOut($user->id));
             });

--- a/database/migrations/2026_04_15_100000_create_attendance_status_types_table.php
+++ b/database/migrations/2026_04_15_100000_create_attendance_status_types_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('attendance_status_types', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 30)->unique();
+            $table->string('label', 60);
+            $table->unsignedSmallInteger('sort_order')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        $now = now();
+        DB::table('attendance_status_types')->insert([
+            [
+                'code' => 'lunch',
+                'label' => 'Lunch',
+                'sort_order' => 0,
+                'is_active' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'code' => 'break',
+                'label' => 'Break',
+                'sort_order' => 1,
+                'is_active' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'code' => 'bio',
+                'label' => 'Bio',
+                'sort_order' => 2,
+                'is_active' => true,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('attendance_status_types');
+    }
+};

--- a/database/migrations/2026_04_15_100001_add_status_type_columns_to_attendance_logs_table.php
+++ b/database/migrations/2026_04_15_100001_add_status_type_columns_to_attendance_logs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('attendance_logs', function (Blueprint $table) {
+            $table->foreignId('attendance_status_type_id')
+                ->nullable()
+                ->after('event_type')
+                ->constrained('attendance_status_types')
+                ->nullOnDelete();
+            $table->string('direction', 10)->nullable()->after('attendance_status_type_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('attendance_logs', function (Blueprint $table) {
+            $table->dropForeign(['attendance_status_type_id']);
+            $table->dropColumn(['attendance_status_type_id', 'direction']);
+        });
+    }
+};

--- a/database/migrations/2026_04_15_100002_extend_attendance_logs_event_type_length.php
+++ b/database/migrations/2026_04_15_100002_extend_attendance_logs_event_type_length.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE attendance_logs MODIFY event_type VARCHAR(80) NOT NULL');
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE attendance_logs MODIFY event_type VARCHAR(30) NOT NULL');
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -13,6 +13,7 @@ import Alpine from 'alpinejs';
 import focus from '@alpinejs/focus';
 import collapse from '@alpinejs/collapse';
 import intersect from '@alpinejs/intersect';
+import './attendance-status';
 
 Alpine.plugin(focus);
 Alpine.plugin(collapse);

--- a/resources/js/attendance-status.js
+++ b/resources/js/attendance-status.js
@@ -1,0 +1,71 @@
+document.addEventListener('alpine:init', () => {
+    window.Alpine.data('attendanceStatusPanel', () => ({
+        open: null,
+        types: [],
+        loading: false,
+        ready: false,
+        async init() {
+            await this.refresh();
+            this.ready = true;
+        },
+        formatStarted(iso) {
+            if (!iso) {
+                return '—';
+            }
+            try {
+                const d = new Date(iso);
+
+                return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+            } catch {
+                return iso;
+            }
+        },
+        async refresh() {
+            try {
+                const { data } = await window.axios.get('/api/attendance/current');
+                if (data.success) {
+                    this.open = data.open;
+                    if (Array.isArray(data.types) && data.types.length) {
+                        this.types = data.types;
+                    }
+                }
+            } catch (e) {
+                console.warn('[attendance]', e);
+            }
+        },
+        async start(code) {
+            this.loading = true;
+            try {
+                await window.axios.post('/api/attendance/start', { code });
+                window.Alpine?.store('toast')?.success?.('Status started.');
+                await this.refresh();
+                window.location.reload();
+            } catch (e) {
+                const msg =
+                    e.response?.data?.message ||
+                    e.response?.data?.errors?.code?.[0] ||
+                    'Could not start status.';
+                window.Alpine?.store('toast')?.error?.(msg);
+            } finally {
+                this.loading = false;
+            }
+        },
+        async end() {
+            this.loading = true;
+            try {
+                await window.axios.post('/api/attendance/end', {});
+                window.Alpine?.store('toast')?.success?.('Status ended.');
+                await this.refresh();
+                window.location.reload();
+            } catch (e) {
+                const msg =
+                    e.response?.data?.message ||
+                    e.response?.data?.errors?.status?.[0] ||
+                    'Could not end status.';
+                window.Alpine?.store('toast')?.error?.(msg);
+            } finally {
+                this.loading = false;
+            }
+        },
+    }));
+});

--- a/resources/views/admin/attendance_logs.blade.php
+++ b/resources/views/admin/attendance_logs.blade.php
@@ -15,6 +15,19 @@
     <div class="p-4">
         <form method="GET" action="{{ route('admin.attendance.index') }}" class="flex flex-wrap items-end gap-4">
             <x-form.input name="date" type="date" label="Date" :value="request('date')" />
+            <div class="form-field min-w-[12rem]">
+                <label class="form-label">{{ __('Event') }}</label>
+                <select name="event" class="form-select">
+                    <option value="">{{ __('All events') }}</option>
+                    <option value="login" @selected(request('event') === 'login')>{{ __('Login') }}</option>
+                    <option value="logout" @selected(request('event') === 'logout')>{{ __('Logout') }}</option>
+                    @foreach($statusTypes ?? [] as $st)
+                        <option value="{{ $st->id }}" @selected((string) request('event') === (string) $st->id)>
+                            {{ $st->label }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
             <div class="form-field">
                 <label class="form-label">&nbsp;</label>
                 <button type="submit" class="btn-primary"><x-icon name="funnel" class="w-4 h-4" /> Filter</button>
@@ -25,16 +38,13 @@
 
 <x-table.index caption="Attendance log entries">
     <x-table.head :columns="[['label' => 'User'], ['label' => 'Event'], ['label' => 'Time'], ['label' => 'IP']]" />
-    @if(isset($logs) && $logs->isEmpty())
-        <x-table.empty :colspan="4" message="No attendance logs." />
-    @else
     <tbody>
         @forelse($logs as $log)
             <tr>
                 <td class="font-medium">{{ $log->user->full_name ?? $log->user->username ?? $log->user_id }}</td>
                 <td>
                     <x-badge :type="$log->event_type === 'login' ? 'active' : ($log->event_type === 'logout' ? 'inactive' : 'info')">
-                        {{ strtoupper($log->event_type) }}
+                        {{ $log->eventDisplayLabel() }}
                     </x-badge>
                 </td>
                 <td class="font-mono text-sm text-[var(--color-on-surface-muted)]">{{ $log->event_time?->timezone(config('app.timezone'))->format('Y-m-d H:i:s T') }}</td>
@@ -44,6 +54,5 @@
             <x-table.empty :colspan="4" message="No attendance logs." />
         @endforelse
     </tbody>
-    @endif
 </x-table.index>
 @endsection

--- a/resources/views/admin/attendance_status_types.blade.php
+++ b/resources/views/admin/attendance_status_types.blade.php
@@ -1,0 +1,114 @@
+@extends('layouts.app')
+
+@section('title', 'Attendance Statuses')
+@section('header-icon')<x-icon name="clock" class="w-5 h-5 text-[var(--color-primary)]" />@endsection
+@section('header-title', 'Attendance Statuses')
+
+@section('content')
+<x-page-header title="Attendance Statuses"
+    :breadcrumbs="['Admin' => route('admin.dashboard'), 'Attendance Statuses' => null]" />
+
+<x-validation-errors />
+
+<div class="md-card mb-6">
+    <div class="px-6 py-4 border-b border-[var(--color-border)]">
+        <h3 class="text-sm font-semibold text-[var(--color-on-surface)]">{{ __('Add status') }}</h3>
+        <p class="text-xs text-[var(--color-on-surface-muted)] mt-1">{{ __('Code: lowercase letters, numbers, underscores. Login/logout remain system-only.') }}</p>
+    </div>
+    <div class="p-6">
+        <form method="POST" action="{{ route('admin.attendance-statuses.store') }}"
+              x-data="{ submitting: false }" @submit="submitting = true">
+            @csrf
+            <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
+                <x-form.input name="code" label="{{ __('Code') }}" required placeholder="e.g. training" />
+                <x-form.input name="label" label="{{ __('Label') }}" required placeholder="{{ __('Training') }}" />
+                <x-form.input name="sort_order" type="number" label="{{ __('Sort order') }}" value="0" />
+                <div class="form-field">
+                    <label class="form-label">&nbsp;</label>
+                    <button type="submit" class="btn-primary" :disabled="submitting">
+                        <x-icon name="plus" class="w-4 h-4" />
+                        {{ __('Add') }}
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<x-table.index caption="{{ __('Attendance status types') }}">
+    <x-table.head :columns="[
+        ['label' => __('Code')],
+        ['label' => __('Label')],
+        ['label' => __('Order')],
+        ['label' => __('Status')],
+        ['label' => __('Actions'), 'align' => 'right'],
+    ]" />
+    <tbody>
+        @forelse($types as $type)
+            <tr>
+                <td><span class="font-mono font-semibold text-sm text-[var(--color-on-surface)]">{{ $type->code }}</span></td>
+                <td>{{ $type->label }}</td>
+                <td>{{ $type->sort_order }}</td>
+                <td>
+                    <x-badge :type="$type->is_active ? 'active' : 'inactive'">
+                        {{ $type->is_active ? __('Active') : __('Inactive') }}
+                    </x-badge>
+                </td>
+                <td>
+                    <div class="table-actions" x-data="{ editOpen: false }">
+                        <button type="button" class="btn-secondary text-xs px-2 py-1" @click="editOpen = !editOpen">
+                            <x-icon name="pencil" class="w-3.5 h-3.5" />
+                            <span x-text="editOpen ? '{{ __('Cancel') }}' : '{{ __('Edit') }}'">{{ __('Edit') }}</span>
+                        </button>
+                        @if($type->is_active)
+                        <div x-data="{ async del(form) {
+                            const ok = await Alpine.store('confirm').ask('{{ __('Deactivate?') }}', '{{ __('This status will no longer appear for new breaks.') }}');
+                            if (ok) form.submit();
+                        }}">
+                            <form method="POST" action="{{ route('admin.attendance-statuses.destroy') }}" x-ref="delForm{{ $type->id }}">
+                                @csrf
+                                <input type="hidden" name="id" value="{{ $type->id }}">
+                                <button type="button" class="btn-danger text-xs px-2 py-1"
+                                        @click="del($refs['delForm{{ $type->id }}'])">
+                                    <x-icon name="trash" class="w-3.5 h-3.5" />
+                                    {{ __('Deactivate') }}
+                                </button>
+                            </form>
+                        </div>
+                        @endif
+                        <div x-show="editOpen" x-collapse
+                             style="display:none; position: absolute; right: 1rem; top: 100%; z-index: 20; background: var(--color-surface-2); border: 1px solid var(--color-border-strong); border-radius: 10px; padding: 1rem; min-width: 28rem; box-shadow: var(--shadow-3);">
+                            <form method="POST" action="{{ route('admin.attendance-statuses.update', $type->id) }}"
+                                  x-data="{ submitting: false }" @submit="submitting = true">
+                                @csrf
+                                @method('PUT')
+                                <div class="grid grid-cols-3 gap-3">
+                                    <x-form.input name="code" label="{{ __('Code') }}" :value="$type->code" />
+                                    <x-form.input name="label" label="{{ __('Label') }}" :value="$type->label" />
+                                    <x-form.input name="sort_order" type="number" label="{{ __('Order') }}" :value="$type->sort_order" />
+                                </div>
+                                <div class="mt-3 flex items-center gap-2">
+                                    <label class="inline-flex items-center gap-2 text-sm text-[var(--color-on-surface-muted)]">
+                                        <input type="hidden" name="is_active" value="0">
+                                        <input type="checkbox" name="is_active" value="1" class="rounded border-[var(--color-border-strong)]"
+                                               @checked($type->is_active)>
+                                        {{ __('Active') }}
+                                    </label>
+                                </div>
+                                <div class="mt-3">
+                                    <button type="submit" class="btn-primary text-sm" :disabled="submitting">
+                                        <x-icon name="check" class="w-4 h-4" />
+                                        {{ __('Update') }}
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        @empty
+            <x-table.empty :colspan="5" message="{{ __('No attendance statuses.') }}" />
+        @endforelse
+    </tbody>
+</x-table.index>
+@endsection

--- a/resources/views/attendance/index.blade.php
+++ b/resources/views/attendance/index.blade.php
@@ -15,12 +15,44 @@
             @if($lastEvent)
                 <p class="text-[var(--color-on-surface-muted)] mt-3 text-sm">
                     Last event:
-                    <x-badge :type="$lastEvent->event_type === 'login' ? 'active' : 'inactive'">{{ strtoupper($lastEvent->event_type) }}</x-badge>
+                    <x-badge :type="$lastEvent->event_type === 'login' ? 'active' : ($lastEvent->event_type === 'logout' ? 'inactive' : 'info')">{{ $lastEvent->eventDisplayLabel() }}</x-badge>
                     <span class="ml-1">{{ $lastEvent->event_time?->timezone(config('app.timezone'))->format('M j, Y g:i A T') }}</span>
                 </p>
             @endif
         </div>
         <x-app-live-clock class="w-full shrink-0 md:max-w-sm" />
+    </div>
+</div>
+
+<div class="md-card mb-4" x-data="attendanceStatusPanel()" x-init="init()">
+    <div class="px-6 py-4 border-b border-[var(--color-border)]">
+        <h3 class="text-sm font-semibold text-[var(--color-on-surface)]">{{ __('Away status') }}</h3>
+        <p class="text-xs text-[var(--color-on-surface-muted)] mt-1">{{ __('Start or end lunch, break, or other statuses configured by your administrator. Login and logout are recorded automatically.') }}</p>
+    </div>
+    <div class="p-6">
+        <p class="text-sm text-[var(--color-on-surface-muted)]" x-show="!ready">{{ __('Loading…') }}</p>
+        <template x-if="ready && open">
+            <div class="flex flex-wrap items-center gap-3">
+                <x-badge type="info"><span x-text="open?.label"></span></x-badge>
+                <span class="text-sm text-[var(--color-on-surface-muted)]" x-show="open?.started_at">
+                    {{ __('Since') }} <span x-text="formatStarted(open?.started_at)"></span>
+                </span>
+                <button type="button" class="btn-primary" :disabled="loading" @click="end()">
+                    <x-icon name="check" class="w-4 h-4" />
+                    {{ __('End status') }}
+                </button>
+            </div>
+        </template>
+        <template x-if="ready && !open && types.length">
+            <div class="flex flex-wrap gap-2">
+                <template x-for="t in types" :key="t.code">
+                    <button type="button" class="btn-secondary text-sm" :disabled="loading" @click="start(t.code)" x-text="'{{ __('Start') }} ' + t.label"></button>
+                </template>
+            </div>
+        </template>
+        <p class="text-sm text-[var(--color-on-surface-dim)]" x-show="ready && !open && !types.length">
+            {{ __('No away statuses are available. Ask a Super Admin to configure them under Admin → Attendance Statuses.') }}
+        </p>
     </div>
 </div>
 
@@ -49,7 +81,7 @@
             <tr>
                 <td>
                     <x-badge :type="$log->event_type === 'login' ? 'active' : ($log->event_type === 'logout' ? 'inactive' : 'info')">
-                        {{ strtoupper($log->event_type) }}
+                        {{ $log->eventDisplayLabel() }}
                     </x-badge>
                 </td>
                 <td class="font-mono text-sm text-[var(--color-on-surface-muted)]">{{ $log->event_time?->timezone(config('app.timezone'))->format('Y-m-d H:i:s T') }}</td>
@@ -59,4 +91,5 @@
     </tbody>
     @endif
 </x-table.index>
+
 @endsection

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -51,6 +51,7 @@
         ['route' => 'admin.campaigns.index',        'label' => 'Campaigns',        'icon' => 'building-office'],
         ['route' => 'admin.forms.index',            'label' => 'Forms',            'icon' => 'document-text'],
         ['route' => 'admin.agent-screen.index',     'label' => 'Agent Screen Cfg', 'icon' => 'computer-desktop'],
+        ['route' => 'admin.attendance-statuses.index', 'label' => 'Attendance Statuses', 'icon' => 'clock'],
         ['route' => 'admin.configuration',          'label' => 'Configuration',    'icon' => 'cog-6-tooth'],
     ];
 @endphp

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,6 +101,9 @@ Route::middleware(['auth', 'campaign'])->group(function () {
     Route::post('api/disposition/save', \App\Http\Controllers\Api\SaveDispositionController::class)->name('api.disposition.save')->middleware('throttle:api');
     Route::post('api/client-errors', fn () => response()->json(['ok' => true]))->name('api.client-errors');
     Route::get('attendance', [AttendanceController::class, 'index'])->name('attendance.index');
+    Route::post('api/attendance/start', [\App\Http\Controllers\Api\AttendanceStatusController::class, 'start'])->name('api.attendance.start')->middleware('throttle:api');
+    Route::post('api/attendance/end', [\App\Http\Controllers\Api\AttendanceStatusController::class, 'end'])->name('api.attendance.end')->middleware('throttle:api');
+    Route::get('api/attendance/current', [\App\Http\Controllers\Api\AttendanceStatusController::class, 'current'])->name('api.attendance.current')->middleware('throttle:api');
     Route::middleware('role:Team Leader,Admin,Super Admin')->group(function () {
         Route::get('reports', [ReportsController::class, 'index'])->name('reports.index');
         Route::post('api/supervisor/monitor', [\App\Http\Controllers\Api\SupervisorTelephonyController::class, 'monitor'])->name('api.supervisor.monitor')->middleware('throttle:vicidial');
@@ -158,6 +161,10 @@ Route::middleware(['auth', 'campaign'])->group(function () {
             Route::post('agent-screen', [\App\Http\Controllers\Admin\AgentScreenController::class, 'store'])->name('agent-screen.store');
             Route::put('agent-screen/{field}', [\App\Http\Controllers\Admin\AgentScreenController::class, 'update'])->name('agent-screen.update');
             Route::post('agent-screen/delete', [\App\Http\Controllers\Admin\AgentScreenController::class, 'destroy'])->name('agent-screen.destroy');
+            Route::get('attendance-statuses', [\App\Http\Controllers\Admin\AttendanceStatusTypesController::class, 'index'])->name('attendance-statuses.index');
+            Route::post('attendance-statuses', [\App\Http\Controllers\Admin\AttendanceStatusTypesController::class, 'store'])->name('attendance-statuses.store');
+            Route::put('attendance-statuses/{id}', [\App\Http\Controllers\Admin\AttendanceStatusTypesController::class, 'update'])->name('attendance-statuses.update');
+            Route::post('attendance-statuses/delete', [\App\Http\Controllers\Admin\AttendanceStatusTypesController::class, 'destroy'])->name('attendance-statuses.destroy');
         });
     });
     Route::get('forms/{type}', [FormController::class, 'show'])->name('forms.show')->where('type', '[a-z_]+');


### PR DESCRIPTION
Here’s what was implemented:

### Database
- **`attendance_status_types`** – `code`, `label`, `sort_order`, `is_active`; seeded **lunch**, **break**, **bio**.
- **`attendance_logs`** – nullable `attendance_status_type_id` (FK, `nullOnDelete`), nullable `direction` (`start` / `end`).
- **`event_type`** widened to **VARCHAR(80)** so `{code}_start` / `{code}_end` fit long codes.

### Backend
- Models: [`AttendanceStatusType`](app/Models/AttendanceStatusType.php), updates to [`AttendanceLog`](app/Models/AttendanceLog.php) (`SYSTEM_EVENT_TYPES`, `eventDisplayLabel()`, `statusType()`).
- [`AttendanceStatusService`](app/Services/AttendanceStatusService.php) – `startStatus`, `endStatus`, `getOpenStatus`, `autoCloseOnLogout`.
- [`AuthService`](app/Services/AuthService.php) – calls `autoCloseOnLogout()` before the `logout` log.
- [`AttendanceRepository`](app/Repositories/AttendanceRepository.php) – `logCustomEvent()`, `getLogs(..., $eventFilter)`, `getLastEvent` loads `statusType`.

### HTTP
- **API** (auth): `POST /api/attendance/start`, `POST /api/attendance/end`, `GET /api/attendance/current` → [`AttendanceStatusController`](app/Http/Controllers/Api/AttendanceStatusController.php).
- **Super Admin**: CRUD under `admin/attendance-statuses` → [`AttendanceStatusTypesController`](app/Http/Controllers/Admin/AttendanceStatusTypesController.php) (deactivate = `is_active = false`).

### UI
- [`attendance/index.blade.php`](resources/views/attendance/index.blade.php) – away status card (Alpine + [`attendance-status.js`](resources/js/attendance-status.js) registered before `Alpine.start()`), table uses `eventDisplayLabel()`.
- [`admin/attendance_status_types.blade.php`](resources/views/admin/attendance_status_types.blade.php) – add/list/edit/deactivate.
- [`admin/attendance_logs.blade.php`](resources/views/admin/attendance_logs.blade.php) – event filter + labels.
- [`sidebar.blade.php`](resources/views/layouts/sidebar.blade.php) – **Attendance Statuses** (Super Admin).

### JS
- [`app.js`](resources/js/app.js) – `import './attendance-status'` after Alpine imports.

`php artisan test`: **AuthServiceTest** still passes; several other failures look **unrelated** to this work (DispositionService constructor, CallStateService, DispositionSaveTest).

Run **`npm run build`** (or `npm run dev`) so Vite picks up `attendance-status.js`.