### PR TITLE
Data Master

### DIFF
--- a/app/Http/Controllers/Admin/DataMasterController.php
+++ b/app/Http/Controllers/Admin/DataMasterController.php
@@ -28,11 +28,12 @@ class DataMasterController extends Controller
         $tableName = $forms[$type]['table_name'] ?? $forms[$type]['table'] ?? '';
         $allowedTables = $this->dataMasterService->getAllowedTables($campaignConfig);
         $records = $this->dataMasterService->getRecords($tableName, $allowedTables);
-        $columns = [];
+        $available = null;
         $first = $records->first();
         if ($first) {
-            $columns = array_keys((array) $first);
+            $available = array_keys((array) $first);
         }
+        $layout = $this->dataMasterService->getColumnLayout($campaign, $type, $available);
 
         return view('admin.data_master', [
             'campaign' => $campaign,
@@ -41,7 +42,8 @@ class DataMasterController extends Controller
             'type' => $type,
             'tableName' => $tableName,
             'records' => $records,
-            'columns' => $columns,
+            'columns' => $layout['columns'],
+            'headers' => $layout['headers'],
         ]);
     }
 
@@ -63,13 +65,16 @@ class DataMasterController extends Controller
             return redirect()->route('admin.data-master.index', ['type' => $type])->with('error', 'Record not found.');
         }
 
+        $layout = $this->dataMasterService->getColumnLayout($campaign, $type, array_keys((array) $record));
+
         return view('admin.data_master_edit', [
             'campaign' => $campaign,
             'campaignName' => $request->session()->get('campaign_name', 'CRM'),
             'type' => $type,
             'tableName' => $tableName,
             'record' => $record,
-            'columns' => array_keys((array) $record),
+            'columns' => $layout['columns'],
+            'headers' => $layout['headers'],
         ]);
     }
 

--- a/app/Services/DataMasterService.php
+++ b/app/Services/DataMasterService.php
@@ -2,14 +2,68 @@
 
 namespace App\Services;
 
+use App\Contracts\Repositories\FormFieldRepositoryInterface;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class DataMasterService
 {
     public function __construct(
         protected CampaignService $campaignService,
+        protected FormFieldRepositoryInterface $formFieldRepository,
     ) {}
+
+    /**
+     * Build the default Data Master column layout for a given form.
+     *
+     * Order: `id` first, then fields defined in `form_fields` ordered by `field_order`,
+     * then any remaining DB columns (from the sample row) appended at the end.
+     * Headers use `field_label` where available, otherwise a humanized `field_name`.
+     *
+     * @param  array<int, string>|null  $availableColumns  Column names present in the actual DB row.
+     * @return array{columns: list<string>, headers: array<string, string>}
+     */
+    public function getColumnLayout(
+        string $campaignCode,
+        string $formType,
+        ?array $availableColumns = null,
+    ): array {
+        $fields = $this->formFieldRepository->getFieldsForForm($campaignCode, $formType);
+
+        $ordered = [];
+        $headers = [];
+        foreach ($fields as $field) {
+            $name = (string) $field->field_name;
+            if ($name === '') {
+                continue;
+            }
+            $ordered[] = $name;
+            $label = (string) ($field->field_label ?? '');
+            $headers[$name] = $label !== '' ? $label : Str::headline($name);
+        }
+
+        if ($availableColumns === null) {
+            $columns = array_values(array_unique(array_merge(['id'], $ordered)));
+        } else {
+            $available = array_values(array_unique($availableColumns));
+            $orderedInDb = array_values(array_intersect($ordered, $available));
+            $idFirst = in_array('id', $available, true) ? ['id'] : [];
+            $remaining = array_values(array_diff($available, $idFirst, $orderedInDb));
+            $columns = array_values(array_unique(array_merge($idFirst, $orderedInDb, $remaining)));
+        }
+
+        foreach ($columns as $col) {
+            if (! isset($headers[$col])) {
+                $headers[$col] = Str::headline($col);
+            }
+        }
+
+        return [
+            'columns' => $columns,
+            'headers' => $headers,
+        ];
+    }
 
     /**
      * Returns allowed table names for a given campaign config.

--- a/resources/views/admin/data_master.blade.php
+++ b/resources/views/admin/data_master.blade.php
@@ -28,7 +28,7 @@
     <thead>
         <tr>
             @foreach($columns as $col)
-                <th>{{ $col }}</th>
+                <th>{{ $headers[$col] ?? $col }}</th>
             @endforeach
             <th style="text-align: right">Actions</th>
         </tr>

--- a/resources/views/admin/data_master_edit.blade.php
+++ b/resources/views/admin/data_master_edit.blade.php
@@ -25,7 +25,7 @@
                 @foreach($columns as $col)
                     @if(!in_array($col, ['id', 'created_at', 'updated_at'], true))
                         <div class="mb-4">
-                            <label class="block text-xs font-bold text-gray-600 uppercase mb-1">{{ $col }}</label>
+                            <label class="block text-xs font-bold text-gray-600 uppercase mb-1">{{ $headers[$col] ?? $col }}</label>
                             <input type="text" name="{{ $col }}" value="{{ is_object($record) ? ($record->$col ?? '') : ($record[$col] ?? '') }}" class="w-full px-3 py-2 border border-gray-200 rounded">
                         </div>
                     @endif


### PR DESCRIPTION
**`app/Services/DataMasterService.php`** — new `getColumnLayout($campaign, $formType, $availableColumns)` method:
- Loads fields via `FormFieldRepository::getFieldsForForm()` (already ordered by `field_order`, then `id`).
- Builds `columns` = `['id', ...form_fields in order, ...any remaining DB columns]`.
- Builds `headers` = `field_label` per field, falling back to `Str::headline(field_name)` for unmapped DB columns (e.g. `created_at` → `Created At`).

**`app/Http/Controllers/Admin/DataMasterController.php`** — both `index()` and `edit()` now build columns via `getColumnLayout(...)` instead of `array_keys((array) $first)`, and pass a new `$headers` map to the views.

**`resources/views/admin/data_master.blade.php`** — `<th>{{ $col }}</th>` → `<th>{{ $headers[$col] ?? $col }}</th>`.

**`resources/views/admin/data_master_edit.blade.php`** — the edit form’s `<label>` now uses `$headers[$col] ?? $col`, and the field order follows the same per-form arrangement.

### Behavior
- Switch between forms in the Form Type dropdown → each form now has its own default column order and friendly header labels, driven by what admins have configured for that form under `form_fields`.
- `id` is always first; any DB columns not declared in `form_fields` (including `created_at`, `updated_at`, legacy columns) still appear, appended after the ordered fields, with headline-case labels.
- Same ordering + labels now also apply to the edit screen.

### Notes
- This makes the arrangement a **per-form default for all users**, as you chose. If you later want per-user overrides, the `$layout` pipeline in the controller is the place to merge in a saved preference before passing to the view.
- If you ever want to let admins curate the Data Master order separately from the agent form order, you could introduce a `display_order` (or a separate `data_master_order` column) on `form_fields` — `getColumnLayout` is the only place that needs to change.